### PR TITLE
Support Line Sender

### DIFF
--- a/src/Channels/LineChannel.php
+++ b/src/Channels/LineChannel.php
@@ -42,7 +42,7 @@ class LineChannel
             }
         }
 
-        $sender = $this->manager->sender('line');
+        $sender = $this->manager->sender('line', $message->sender ?? null);
         $response = $sender->send($to, $message);
 
         if ($this->events) {

--- a/src/NotificationServiceProvider.php
+++ b/src/NotificationServiceProvider.php
@@ -28,8 +28,6 @@ class NotificationServiceProvider extends ServiceProvider
     
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/notifications.php', 'notifications');
-
         Notification::resolved(function (ChannelManager $service) {
             $service->extend('mail', function ($app) {
                 return $app->make(MailChannel::class);


### PR DESCRIPTION
- Support Line Sender from Message Config
- Do not register `notifications` config in default Provider